### PR TITLE
Update animations.py

### DIFF
--- a/core/animations.py
+++ b/core/animations.py
@@ -137,10 +137,10 @@ def animate_actor(obj):
 
         # The new pose in which the bone should be (still in Studio space)
         studio_new_pose = Quaternion((
-            actor_bone_data['rotation']['w'],
-            actor_bone_data['rotation']['x'],
-            actor_bone_data['rotation']['y'],
-            actor_bone_data['rotation']['z'],
+            float(actor_bone_data['rotation']['w']),
+            float(actor_bone_data['rotation']['x']),
+            float(actor_bone_data['rotation']['y']),
+            float(actor_bone_data['rotation']['z']),
         ))
 
         # Function to convert from Studio to Blender space


### PR DESCRIPTION
Blender 3.3.1 requires floats to be explicit. String/NaN will always error out.